### PR TITLE
Some edits

### DIFF
--- a/draft-rdb-ohai-feedback-to-proxy-00.xml
+++ b/draft-rdb-ohai-feedback-to-proxy-00.xml
@@ -102,14 +102,14 @@
 
     <abstract>
       <t>To provide equitable service to clients, servers often rate-limit
-      incoming requests, often by source IP address. However Oblivious HTTP
+      incoming requests, often based upon the source IP address. However, oblivious HTTP
       removes the ability for the server to distinguish amongst clients so the
       server can only rate-limit traffic from the Oblivious proxy. This harms
       all clients behind that Oblivious proxy.</t>
 
-      <t>This specification provides feedback from the server to the Oblivious
-      proxy, enabling the Oblivious proxy to rate-limit incoming requests from
-      clients. Cooperating Oblivious proxies can thus provide more equitable
+      <t>This specification provides feedback from a server to an oblivious
+      proxy, enabling the oblivious proxy to rate-limit incoming requests from
+      clients. Cooperating oblivious proxies can thus provide more equitable
       service to their distinguishable clients without triggering
       rate-limiting on the request resource or the target resource that would
       impact all clients behind that Oblivious proxy.</t>
@@ -125,29 +125,29 @@
       responses and enables a deployment architecture that can separate the
       identity of a requester from the request. This scheme requires that
       servers and proxies explicitly support it. The server is susceptible to
-      attacks described below but it cannot take any mitigation action per
+      attacks described below, but the server cannot take any mitigation action per
       client to protect itself from various attacks -- the server can only
-      take mitigation per Oblivious proxy. Rate limiting traffic from an
+      take mitigation actions per Oblivious proxy. Rate-limiting traffic from an
       Oblivious proxy impacts all clients behind that proxy -- both
       misbehaving clients and well-behaved clients.</t>
 
-      <t>Attacks against the Request and Target Resources belong in three
+      <t>Attacks against the Request and Target Resources can be classified into three
       primary categories:</t>
 
       <t><list style="numbers">
-          <t>client sends malformed Encapsulated Request causing decryption
-          failure or decryption overload failure on the Oblivious Request
-          Resource. This causes the Oblivious Request Resource to send an
-          error status code back to the Oblivious Proxy.</t>
+          <t>A client sends a malformed encapsulated request causing decryption
+          failure or decryption overload failure on the oblivious request
+          resource. This causes the oblivious request resource to send an
+          error status code back to the oblivious proxy.</t>
 
-          <t>client sends HTTP transaction that causes an HTTP error on the
-          Oblivious Target Resource (typically a 5xx-series error). This might
+          <t>A client sends an HTTP transaction that causes an HTTP error on the
+          oblivious target tesource (typically, a 5xx error). This might
           be a malformed HTTP request, request for a missing resource, too
           many requests from a single client, too many requests from the
           clients behind the same OHAI proxy, or too many requests from all
           clients on the Internet.</t>
 
-          <t>HTTP flood: A botnet performing an HTTP Flood attack against a
+          <t>HTTP flood: A botnet performing an HTTP flood attack against a
           victim's server. Because each bot in a botnet makes seemingly
           legitimate network requests the traffic is not spoofed and may
           appear "normal" in origin.</t>
@@ -155,44 +155,44 @@
 
       <!--
 
-      <t>The Request Resource defined in <xref
+      <t>The request resource defined in <xref
       target="I-D.ietf-ohai-ohttp"></xref> is susceptible to the following
       attacks:</t>
 
       <t><list style="symbols">
-          <t>Bogus encapsulated request: Decryption of Encapsulated Request
+          <t>Bogus encapsulated requests: Decryption of an encapsulated request
           would fail and the server returns an error, wasting CPU cycles on
           the request resource.</t>
 
-          <t>Bogus keyID: The server cannot find HPKE private key, skR,
+          <t>Bogus keyIDs: The server cannot find HPKE private key, skR,
           corresponding to keyID and the server returns an error, wasting CPU
           cycles to do a look of the HPKE private key.</t>
 
-          <t>Garbled encapsulated request: The server cannot parse the
+          <t>Garbled encapsulated requests: The server cannot parse the
           encapsulated request into keyID, kemID, kdfID, aeadID, enc, and ct,
           wasting CPU cycles to parse the encapsulated request.</t>
         </list></t>
 
-      <t>The Target Resource defined in <xref
+      <t>The target resource defined in <xref
       target="I-D.ietf-ohai-ohttp"></xref> is susceptible to the following
       attacks:</t>
 
       <t><list style="symbols">
-          <t>Partial or Bogus HTTP request: The client sends partial or
+          <t>Partial or bogus HTTP requests: The client sends partial or
           garbled HTTP requests to overwhelm the server to process bogus
           requests, wasting CPU and network bandwidth on the server.</t>
 
-          <t>HTTP flood: A botnet performing an HTTP Flood attack against a
+          <t>HTTP flood: A botnet performing an HTTP flood attack against a
           victim's server. Because each bot in a botnet makes seemingly
           legitimate network requests the traffic is not spoofed and may
-          appear &ldquo;normal&rdquo; in origin.</t>
+          appear "normal" in origin.</t>
         </list></t>
 
 
-      <t>Without OHAI, attacks on an HTTPserver can be mitigated by filtering
-      the sender's IP address, this would result in blocking the proxy
+      <t>Without OHAI, attacks on an HTTP server can be mitigated by filtering
+      based upon the sender's IP address. This would result in blocking the proxy
       resource and adversely impact other, non-attacking clients using that
-      same Oblivious proxy. For example, Web Application Firewall (WAF) <xref
+      same oblivious proxy. For example, Web Application Firewall (WAF) <xref
       target="WAF1"></xref><xref target="WAF2"></xref> typically has the
       capability to identify and block requests to web applications from a
       VPN, Tor exit nodes, proxies, and data centers by using specific Access
@@ -203,13 +203,13 @@
 
 -->
 
-      <t>This document defines how overload is communicated to an Oblivious
-      Proxy so that Oblivious Proxy can rate limit transactions by overzealous
-      or misbehaving clients, allowing the Oblivious Proxy to continue
-      servicing well-behaved clients to that same Oblivious Target
-      Resource.</t>
+      <t>This document defines how an overload indication is communicated to an oblivious
+      proxy so that this Proxy can rate limit transactions by overzealous
+      or misbehaving clients, allowing the oblivious proxy to continue
+      servicing well-behaved clients to that same oblivious target
+      tesource.</t>
 
-      <t>The Oblivious Target Resource and Oblivious Proxy do not need any
+      <t>The oblivious target tesource and oblivious proxy do not need any
       prior agreement to use the protocol described in this document -- which
       contrasts with DOTS <xref target="RFC9132"></xref>.</t>
     </section>
@@ -221,7 +221,7 @@
       <xref target="RFC2119"></xref><xref target="RFC8174"></xref> when, and
       only when, they appear in all capitals, as shown here.</t>
 
-      <t>This document makes use of the terms defined in Oblivious HTTP <xref
+      <t>This document makes use of the terms defined in <xref
       target="I-D.ietf-ohai-ohttp"></xref>.</t>
     </section>
 
@@ -254,14 +254,14 @@
 ]]></artwork>
         </figure><list style="empty">
           <t>[[NOTE: CHECK IF WE CAN REUSE THE STRUCTURED FIELDS IN RFC
-          rfc8941]]</t>
+          8941]]</t>
         </list></t>
 
       <t>Optional white space (OWS) is used as defined in Section 3.2.3 of
-      <xref target="RFC7230"></xref> and token are used as defined in Section
+      <xref target="RFC7230"></xref> and token is used as defined in Section
       3.2.6 of <xref target="RFC7230"></xref>.</t>
 
-      <t>The overall processing of the parameters are discussed below: <list
+      <t>The overall processing of the parameters is discussed below: <list
           style="numbers">
           <t>The order of appearance of the parameters is not significant.</t>
 
@@ -274,7 +274,7 @@
           <t>Parameter names are case insensitive.</t>
 
           <t>Proxies MUST ignore any parameters or values, that do not conform
-          to the syntax defined in this specification. In particular, Proxies
+          to the syntax defined in this specification. In particular, proxies
           must not attempt to fix malformed parameters or parameter
           values.</t>
 
@@ -298,14 +298,14 @@
           <t hangText="p-req:">The maximum number of HTTP requests allowed per
           second from the proxy. This is an optional attribute.</t>
 
-          <t hangText="p-outstanding:">The maximum number of outstanding HTTP
+          <t hangText="po:">The maximum number of outstanding HTTP
           requests allowed from the proxy. This is an optional attribute.</t>
 
           <t hangText="c-req:">The maximum number of HTTP requests allowed per
           second from the client which has sent malformed request. This is an
           optional attribute.</t>
 
-          <t hangText="c-outstanding:">The maximum number of outstanding HTTP
+          <t hangText="co:">The maximum number of outstanding HTTP
           requests allowed from the client which has sent malformed request.
           This is an optional attribute.</t>
 
@@ -323,7 +323,7 @@
 
       <t>The above parameters are in the form of a name=value pair. The
       feedback information header MUST include atleast one of the parameters
-      c-any-req, c-any-outstanding, p-req, p-outstanding, c-req or
+      c-req, co, p-req, po, c-req or
       c-outstanding.</t>
 
       <t>Example:</t>
@@ -332,21 +332,21 @@
           <artwork><![CDATA[  HTTP/1.1 200 OK 
   Date: Wed, 27 March 2022 04:45:07 GMT 
   Cache-Control: private, no-store 
-  Feedback: c-any-req=1000; p--any-outstanding=200; td=600
+  Feedback: c-req=1000; po=200; td=600
   Content-Type: message/ohttp-res
   Content-Length: 38 <content is the encapsulated response>]]></artwork>
         </figure></t>
     </section>
 
     <section anchor="Generate"
-             title="Request or Target Resource generating Feedback Header">
+             title="Request or Target Resource Generating Feedback Header">
       <t>When an overlaod is experienced by the request or target resource it
       adds the Feedback header and parameters to request load adjustement. For
       example, when a WAF or HTTP server itself identifies high frequency or
       high volume anomalies in the traffic directed to the server it would
       include the Feedback header. Ideally the Feedback header provides enough
-      detail to the Oblivious proxy to avoid the server rate limiting the
-      Oblivious proxy's IP address.</t>
+      detail to the oblivious proxy to avoid the server rate limiting the
+      oblivious proxy's IP address.</t>
     </section>
 
     <section anchor="Proxy-process"


### PR DESCRIPTION
Align with draft-ietf-ohai-ohttp
use short parameter names to follow HTTP extension bcp